### PR TITLE
Handle user login attemp on unauthorized panel

### DIFF
--- a/packages/panels/src/Pages/Auth/Login.php
+++ b/packages/panels/src/Pages/Auth/Login.php
@@ -74,6 +74,14 @@ class Login extends SimplePage
                 'data.email' => __('filament-panels::pages/auth/login.messages.failed'),
             ]);
         }
+                
+        if (! Filament::auth()->user()->canAccessPanel(Filament::getCurrentPanel())) {
+            Filament::auth()->logout();
+
+            throw ValidationException::withMessages([
+                'data.email' => __('filament-panels::pages/auth/login.messages.failed'),
+            ]);
+        }
 
         session()->regenerate();
 


### PR DESCRIPTION
Hello,

When a user tries to login on a panel for which he doesn't have permissions, he's shown a 403 error but the user remains logged in.

This PR verifies that the user has access to the panel during the login process, and if the user isn't allowed to access the panel, it logouts the user and show the credentials mismatch validation error.