### PR TITLE
Button with custom size: fix Attempt to read property "value" on string

### DIFF
--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -39,6 +39,8 @@
         $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
+    $sizeClassSuffix = $size instanceof ActionSize ? $size->value : null;
+
     $iconSize ??= match ($size) {
         ActionSize::ExtraSmall, ActionSize::Small => IconSize::Small,
         default => IconSize::Medium,
@@ -62,9 +64,9 @@
             // @deprecated `fi-btn-color-*` has been replaced by `fi-color-*` and `fi-color-custom`.
             is_string($color) ? "fi-btn-color-{$color}" : null,
             is_string($color) ? "fi-color-{$color}" : null,
-            "fi-size-{$size->value}" => $size instanceof ActionSize,
+            "fi-size-{$sizeClassSuffix}" => $size instanceof ActionSize,
             // @deprecated `fi-btn-size-*` has been replaced by `fi-size-*`.
-            "fi-btn-size-{$size->value}" => $size instanceof ActionSize,
+            "fi-btn-size-{$sizeClassSuffix}" => $size instanceof ActionSize,
             match ($size) {
                 ActionSize::ExtraSmall => 'gap-1 px-2 py-1.5 text-xs',
                 ActionSize::Small => 'gap-1 px-2.5 py-1.5 text-sm',

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -39,8 +39,6 @@
         $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
-    $sizeClassSuffix = $size instanceof ActionSize ? $size->value : null;
-
     $iconSize ??= match ($size) {
         ActionSize::ExtraSmall, ActionSize::Small => IconSize::Small,
         default => IconSize::Medium,
@@ -64,9 +62,9 @@
             // @deprecated `fi-btn-color-*` has been replaced by `fi-color-*` and `fi-color-custom`.
             is_string($color) ? "fi-btn-color-{$color}" : null,
             is_string($color) ? "fi-color-{$color}" : null,
-            $sizeClassSuffix ? "fi-size-{$sizeClassSuffix}" : null,
+            ($size instanceof ActionSize) ? "fi-size-{$size->value}" : null,
             // @deprecated `fi-btn-size-*` has been replaced by `fi-size-*`.
-            $sizeClassSuffix ? "fi-btn-size-{$sizeClassSuffix}" : null,
+            ($size instanceof ActionSize) ? "fi-btn-size-{$size->value}" : null,
             match ($size) {
                 ActionSize::ExtraSmall => 'gap-1 px-2 py-1.5 text-xs',
                 ActionSize::Small => 'gap-1 px-2.5 py-1.5 text-sm',

--- a/packages/support/resources/views/components/button/index.blade.php
+++ b/packages/support/resources/views/components/button/index.blade.php
@@ -64,9 +64,9 @@
             // @deprecated `fi-btn-color-*` has been replaced by `fi-color-*` and `fi-color-custom`.
             is_string($color) ? "fi-btn-color-{$color}" : null,
             is_string($color) ? "fi-color-{$color}" : null,
-            "fi-size-{$sizeClassSuffix}" => $size instanceof ActionSize,
+            $sizeClassSuffix ? "fi-size-{$sizeClassSuffix}" : null,
             // @deprecated `fi-btn-size-*` has been replaced by `fi-size-*`.
-            "fi-btn-size-{$sizeClassSuffix}" => $size instanceof ActionSize,
+            $sizeClassSuffix ? "fi-btn-size-{$sizeClassSuffix}" : null,
             match ($size) {
                 ActionSize::ExtraSmall => 'gap-1 px-2 py-1.5 text-xs',
                 ActionSize::Small => 'gap-1 px-2.5 py-1.5 text-sm',

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -36,8 +36,6 @@
         $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
-    $sizeClassSuffix = $size instanceof ActionSize ? $size->value : null;
-
     $iconSize ??= match ($size) {
         ActionSize::ExtraSmall, ActionSize::Small => IconSize::Small,
         default => IconSize::Medium,
@@ -51,9 +49,9 @@
         'fi-link group/link relative inline-flex items-center justify-center outline-none',
         'pe-4' => $badge,
         'pointer-events-none opacity-70' => $disabled,
-        $sizeClassSuffix ? "fi-size-{$size->value}" : null,
+        ($size instanceof ActionSize) ? "fi-size-{$size->value}" : null,
         // @deprecated `fi-link-size-*` has been replaced by `fi-size-*`.
-        $sizeClassSuffix ? "fi-link-size-{$size->value}" : null,
+        ($size instanceof ActionSize) ? "fi-link-size-{$size->value}" : null,
         match ($size) {
             ActionSize::ExtraSmall => 'gap-1',
             ActionSize::Small => 'gap-1',

--- a/packages/support/resources/views/components/link.blade.php
+++ b/packages/support/resources/views/components/link.blade.php
@@ -36,6 +36,8 @@
         $size = filled($size) ? (ActionSize::tryFrom($size) ?? $size) : null;
     }
 
+    $sizeClassSuffix = $size instanceof ActionSize ? $size->value : null;
+
     $iconSize ??= match ($size) {
         ActionSize::ExtraSmall, ActionSize::Small => IconSize::Small,
         default => IconSize::Medium,
@@ -49,9 +51,9 @@
         'fi-link group/link relative inline-flex items-center justify-center outline-none',
         'pe-4' => $badge,
         'pointer-events-none opacity-70' => $disabled,
-        "fi-size-{$size->value}" => $size instanceof ActionSize,
+        $sizeClassSuffix ? "fi-size-{$size->value}" : null,
         // @deprecated `fi-link-size-*` has been replaced by `fi-size-*`.
-        "fi-link-size-{$size->value}" => $size instanceof ActionSize,
+        $sizeClassSuffix ? "fi-link-size-{$size->value}" : null,
         match ($size) {
             ActionSize::ExtraSmall => 'gap-1',
             ActionSize::Small => 'gap-1',


### PR DESCRIPTION
## Description

When using button component with custom size an exception is thrown:

```php
<x-filament::button
    size="gap-1.5 px-4 py-3 text-xl"
>
    New
</x-filament::button>
```

## Visual changes

Nothing

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
